### PR TITLE
Add rules for branches and releases

### DIFF
--- a/process/naming.md
+++ b/process/naming.md
@@ -1,0 +1,72 @@
+# Naming conventions
+
+- [Branches](#branches)
+- [Release tags](#release-tags)
+
+This document describes the approach to name branches and releases on repos
+maintained by the Xen-Troops team.
+
+---
+## Branches
+We have two types of repos:
+- our repos, i.e. created and developed by Xen-Troops team
+- forks from the open-source
+
+### Our repos
+For our repos we maintain the `main`/`master` branch as the working,
+compilable, and more or less tested. This branch is used for releases.
+Development branches should be created on the developer's fork of the main
+repo and should be merged into the main branch after the review.
+In some cases, we may create a permanent branch but this has to have good
+reasoning.
+For example, repo upgrades to a new version of the yocto, but we still have
+to maintain the previous version due to the needs of other repos.
+In such case, we may create a side branch to keep some fixes for the old
+yocto, but the main branch upgrades and development of the repo is going
+on the main branch.
+E.g.: `meta-xt-common` is going to switch from the `dunfell` to `kirkstone`.
+So we create the branch `dunfell` and upgrade the master to the `kirkstone`.
+And for some time we maintain the `dunfell` branch as well as the main one.
+
+### Forks from the open source
+We keep the `main`/`master` branch as the mirror of the original repo only.
+In most cases, it is outdated and updated occasionally.
+All development is going on the our branches for specific needs. The branch
+name should contain:
+- platform-specific prefix, if needed
+- clearly specified base release of the upstream
+- `-xt` suffix, so we can distinguish our branches
+Something like `<platform>-<upstream release>-xt`. Dash `-` or slash `/`
+should be used as the separator.
+
+Examples of acceptable names for branches:
+- xen-troops/uboot: rpi5-2024.04-xt
+- xen-troops/zephyr: zephyr/v3.6.0/xt
+- xen-troops/linux: v5.10.41/rcar-5.1.7.rc11.2-xt
+- xen-troops/xen: xen-4.19-xt0.1
+
+We have the same requirement for those branches as for the main branch on
+our repos - they are working, compilable, and more or less tested.
+Suitable for the release.
+
+---
+## Release tags
+And again, we have slightly different approaches for our repos and our forks
+of the open-source repos.
+
+### Our repos
+We use SymVer with a `v` prefix and three numbers separated by the dot `.`.
+So, proper release tags for our repos: `v1.0.0`, `v0.1.0`, `v2.0.3`.
+That simple.
+
+### Forks from the open source
+This one is more complex, taking into account that we may have branches for
+different platforms, different upstream releases on the same platform, and
+our releases above upstream releases. So we should take the name of our
+branch and append `-vX.Y.Z`.
+Examples of release tags:
+- xen-troops/uboot: rpi5-2024.04-xt-v1.0.0
+- xen-troops/zephyr: zephyr/v3.6.0/xt-v1.0.0
+
+It's quite easy to understand which branch was used for the release and
+to find all releases for your branch.

--- a/process/releases.md
+++ b/process/releases.md
@@ -1,0 +1,30 @@
+# Requirements for releases
+
+Each repo has its release schedule. Release may be created for different
+reasons, like:
+- obligations before the customer
+- significant change in the API provided by the project
+- the need to change the build base, like upgrade the yocto version
+- the periodic milestone of the actively developing project
+- ...
+
+Despite the reasons, the release has the following requirements:
+- all external dependencies have to be fixed using the commit hash or
+release tag only
+- the usage of the developer's forks of the xen-troops' repos is not acceptable
+- the head of the branch of the external repo can't be used in the release
+
+To be more specific:
+- for yocto recipes, if SRC_URI has any internet link, there has to be SRCREV
+with the commit hash or release tag (AUTOREV can't be used)
+- any component mentioned in the `sources:` block of the moulin configuration
+(.yaml) has to have `rev:` set to the commit hash or release tag (branch name
+can't be used)
+- android manifest has to have fixed commits
+
+Before the release, we need to take into account the impact on other dependable
+repos. This means, that release notes have to describe:
+- changes in the provided API
+- changes in build requirements
+- expected build issues and possible solutions
+- known issues with workaround


### PR DESCRIPTION
Describe some rules for the xen-troops repos:
- the usage of the branches
- the naming of the branches
- the fixing of the releases
- the naming of the release tags