### PR TITLE
Update process-related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Product descriptions can be found [here](products)
 [Naming of branches and releases](process/naming.md)
 
 [Requirements for releases](process/releases.md)
+
+[How to handle inter-repo dependencies](process/inter-repo.md)

--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ Old wiki is located in [manifest wiki](https://github.com/xen-troops/manifests/w
 
 Product descriptions can be found [here](products)
 
-Want to contribute? Please see [contribution guideline](contribution).
+## Xen-troops process
+
+[Requirements for the pull request](process/process.md).
+
+[Naming of branches and releases](process/naming.md)
+
+[Requirements for releases](process/releases.md)

--- a/process/inter-repo.md
+++ b/process/inter-repo.md
@@ -1,0 +1,24 @@
+# How to handle inter-repo dependencies
+
+Taking into account that our repos have complex and sometimes nested
+compile-time dependencies between repositories, we have to describe rules and
+recommendations to reduce unexpected issues.
+
+## Rule 1. Fix everything
+As much as possible avoid referring to other repos using the branch name.
+Use known-to-be-good commit hash or release tag.
+When you use the branch name of the actively developing repo, you may meet
+unexpected issues on any day. Your product may become not compilable, you may
+get a few additional hours of build time, or the product may become broken at
+the least expected moment.
+Fix all external dependencies to avoid unexpected issues.
+
+## Rule 2. Update dependencies reasonably
+If you know that the external repo is actively developing, then update it
+periodically.
+This allows you to be aware of the possible issue early, and avoid complex
+upgrades and rework.
+This rule is especially important if you work in a team. It's always better
+one team member will spend time to resolve upgrade related issues, and
+provide known-to-be-good upgrade commits, than all team will stuck due to
+unintended changes in the external repo.

--- a/process/naming.md
+++ b/process/naming.md
@@ -51,13 +51,23 @@ Suitable for the release.
 
 ---
 ## Release tags
-And again, we have slightly different approaches for our repos and our forks
+The main rule - is that release tags can't be moved after creation. If
+fixes/updates are made to the release, then a new release tag should
+be created according to release rules and SemVer requirements.
+
+We have slightly different approaches for our repos and our forks
 of the open-source repos.
 
 ### Our repos
 We use SymVer with a `v` prefix and three numbers separated by the dot `.`.
 So, proper release tags for our repos: `v1.0.0`, `v0.1.0`, `v2.0.3`.
 That simple.
+
+In some rare cases, we may need to create platform-specific branches on our
+repo. In this case, we should follow the below-mentioned rule "Forks from
+the open source" and use branch-specific prefix.
+But in general, we should avoid these cases, and reconsider the approach
+based on creating release tags on the non-main branch on our repo.
 
 ### Forks from the open source
 This one is more complex, taking into account that we may have branches for

--- a/process/releases.md
+++ b/process/releases.md
@@ -51,3 +51,16 @@ repos. This means, that release notes have to describe:
 - changes in build requirements
 - expected build issues and possible solutions
 - known issues with workaround
+
+## Release branches
+We make the release from the main branch of our repo in most cases.
+Only in some rare cases, we release from the already existing
+platform-specific branch. But this need should be seriously considered
+and require management review & approval.
+
+For the release, we should create the release branch `vX.Y` from the main
+branch. So, for the release `2.3.0` we use branch `v2.3`.
+All hotfixes for that release have to be added to the same release branch
+with the new release tag.
+For example, hotfix was made for the release `2.3.0`. It must be pushed
+into the branch `v2.3`, and have to be tagged as `v2.3.1`.


### PR DESCRIPTION
- naming.md: add the rule to not move tags 
- releases.md: how to handle self-references in projects 
- README.md: add Xen-troops process section 
- Add description for the inter-repo dependencies 